### PR TITLE
Cache kahypar build

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -15,21 +15,6 @@ jobs:
         with:
           python-version: 3.9.12
 
-      - name: Install boost
-        run: sudo apt-get install libboost-all-dev
-
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.12
-        with:
-          cmake-version: 3.16.x
-
-      - name: Checkout kahypar
-        uses: actions/checkout@v2
-        with: 
-          repository: kahypar/kahypar
-          submodules: recursive
-          fetch-depth: 1
-
       - name: Cache kahypar Build
         id: cache-kahypar
         uses: actions/cache@v3
@@ -37,15 +22,32 @@ jobs:
           path: ~/kahypar.cpython-39-x86_64-linux-gnu.so
           key: kahypar_cache
 
-      - if: ${{ steps.cache-kahypar.outputs.cache-hit != 'true' }}
-        name: Build kahypar
+      - name: Install boost
+        if: ${{ steps.cache-kahypar.outputs.cache-hit != 'true' }}
+        run: sudo apt-get install libboost-all-dev
+
+      - name: Setup cmake
+        if: ${{ steps.cache-kahypar.outputs.cache-hit != 'true' }}
+        uses: jwlawson/actions-setup-cmake@v1.12
+        with:
+          cmake-version: 3.16.x
+
+      - name: Checkout kahypar
+        if: ${{ steps.cache-kahypar.outputs.cache-hit != 'true' }}
+        uses: actions/checkout@v2
+        with: 
+          repository: kahypar/kahypar
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Build kahypar
+        if: ${{ steps.cache-kahypar.outputs.cache-hit != 'true' }}
         run: |
           mkdir build && cd build
           cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DKAHYPAR_PYTHON_INTERFACE=1 -DBUILD_TESTING=OFF
           make
           cd python
           make
-          pwd
           cp kahypar.cpython-39-x86_64-linux-gnu.so ~/
 
       - name: Install kahypar


### PR DESCRIPTION
A small change to use cached builds of kahypar to speed up remote tests.