### PR TITLE
Add no symbols check to gate set predicate

### DIFF
--- a/src/pytket_dqc/utils/gateset.py
+++ b/src/pytket_dqc/utils/gateset.py
@@ -1,4 +1,8 @@
-from pytket.predicates import GateSetPredicate  # type: ignore
+from pytket.predicates import (  # type: ignore
+    GateSetPredicate,
+    NoSymbolsPredicate,
+    UserDefinedPredicate
+)
 from pytket import OpType
 from pytket.passes import (  # type: ignore
     auto_rebase_pass,
@@ -8,8 +12,17 @@ from pytket.passes import (  # type: ignore
 dqc_gateset = {OpType.Rx, OpType.CZ, OpType.Rz, OpType.CX,
                OpType.Measure, OpType.CRz}
 
+
+def check_function(circ):
+
+    return (
+        NoSymbolsPredicate().verify(circ) and
+        GateSetPredicate(dqc_gateset).verify(circ)
+    )
+
+
 #: Predicate for checking gateset is valid
-dqc_gateset_predicate = GateSetPredicate(dqc_gateset)
+dqc_gateset_predicate = UserDefinedPredicate(check_function)
 
 #: Pass rebasing gates to those valid within pytket-dqc
 dqc_rebase = auto_rebase_pass(dqc_gateset)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -9,6 +9,7 @@ from pytket_dqc.networks import NISQNetwork
 from pytket_dqc.distributors import Brute
 from pytket_dqc.placement import Placement
 import networkx as nx  # type: ignore
+from sympy import Symbol  # type: ignore
 
 
 def test_rebase():
@@ -59,3 +60,12 @@ def test_direct_from_origin():
 
     assert direct_from_origin(G_reordered, 1) == from_one_ideal
     assert direct_from_origin(G_reordered, 2) == from_two_ideal
+
+
+def test_symbolic_circuit():
+
+    a = Symbol("alpha")
+    circ = Circuit(1)
+    circ.Rx(a, 0)
+
+    assert not dqc_gateset_predicate.verify(circ)


### PR DESCRIPTION
We don't support symbolic gates at present. This is a quick check that we can add around the code base as needed.