### PR TITLE
Remove save_circuit lines which save the circuit output to a binary file

### DIFF
--- a/examples/packing-examples.ipynb
+++ b/examples/packing-examples.ipynb
@@ -26,9 +26,13 @@
     "from pytket import Circuit\n",
     "from pytket.circuit.display import render_circuit_jupyter\n",
     "from pytket_dqc.networks import NISQNetwork\n",
-    "from pytket_dqc.distributors import GraphPartitioning, Annealing\n",
+    "from pytket_dqc.distributors import Random\n",
     "from pytket_dqc.circuits import DistributedCircuit, BipartiteCircuit\n",
-    "from pytket.transform import Transform"
+    "from pytket.transform import Transform\n",
+    "import pickle\n",
+    "\n",
+    "seed = 27\n",
+    "distributor = Random()"
    ]
   },
   {
@@ -62,10 +66,8 @@
     "    {0: [0], 1: [1]}\n",
     ")\n",
     "render_circuit_jupyter(circuit)\n",
-    "\n",
     "dist_circ = DistributedCircuit(circuit)\n",
-    "distributor = GraphPartitioning()\n",
-    "placement = distributor.distribute(dist_circ, network)"
+    "placement = distributor.distribute(dist_circ, network, seed = seed)"
    ]
   },
   {
@@ -104,8 +106,7 @@
     "render_circuit_jupyter(circuit)\n",
     "\n",
     "dist_circ = DistributedCircuit(circuit)\n",
-    "distributor = GraphPartitioning()\n",
-    "placement = distributor.distribute(dist_circ, network)"
+    "placement = distributor.distribute(dist_circ, network, seed = seed)"
    ]
   },
   {
@@ -146,8 +147,7 @@
     "render_circuit_jupyter(circuit)\n",
     "\n",
     "dist_circ = DistributedCircuit(circuit)\n",
-    "distributor = GraphPartitioning()\n",
-    "placement = distributor.distribute(dist_circ, network)"
+    "placement = distributor.distribute(dist_circ, network, seed = seed)"
    ]
   },
   {
@@ -188,8 +188,7 @@
     "render_circuit_jupyter(circuit)\n",
     "\n",
     "dist_circ = DistributedCircuit(circuit)\n",
-    "distributor = GraphPartitioning()\n",
-    "placement = distributor.distribute(dist_circ, network)"
+    "placement = distributor.distribute(dist_circ, network, seed = seed)"
    ]
   },
   {
@@ -229,8 +228,7 @@
     "render_circuit_jupyter(circuit)\n",
     "\n",
     "dist_circ = DistributedCircuit(circuit)\n",
-    "distributor = GraphPartitioning()\n",
-    "placement = distributor.distribute(dist_circ, network)"
+    "placement = distributor.distribute(dist_circ, network, seed = seed)"
    ]
   },
   {
@@ -266,8 +264,7 @@
     "render_circuit_jupyter(circuit)\n",
     "\n",
     "dist_circ = DistributedCircuit(circuit)\n",
-    "distributor = GraphPartitioning()\n",
-    "placement = distributor.distribute(dist_circ, network)"
+    "placement = distributor.distribute(dist_circ, network, seed = seed)"
    ]
   },
   {


### PR DESCRIPTION
These were accidently included in the previous example jupyter notebook