### PR TITLE
Add methods to hypergraph circuit

### DIFF
--- a/src/pytket_dqc/circuits/hypergraph_circuit.py
+++ b/src/pytket_dqc/circuits/hypergraph_circuit.py
@@ -466,7 +466,7 @@ class HypergraphCircuit(Hypergraph):
         """Given two gate vertices and a qubit vertex, return all commands
         in the circuit after the gate corresponding to ``first_vertex`` and up
         until the gate corresponding to ``second_vertex``.
-        
+
         NOTE: the ``first_vertex`` and ``second_vertex`` gates aren't included
         NOTE: only the commands acting on ``qubit_vertex`` are included.
         """


### PR DESCRIPTION
This implements several new methods on `HypergraphCircuit` from other PRs

From #47 
- `get_vertex_to_command_index_map()`
- `_sorted_hedges_predicate()`
- `get_last_command_index()`
- `get_first_command_index()`

From #48 
- `get_qubit_of_vertex()`
- `get_gate_of_vertex()`